### PR TITLE
Fix undefined method sanitize error in rails 5.1.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,9 @@ Style/Encoding:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/IndentHeredoc:
+  Enabled: false
+
 Style/MultilineMethodCallIndentation:
   Enabled: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
   - 2.0.0-p648
 
 gemfile:
+  - gemfiles/active_record_edge.gemfile
+  - gemfiles/active_record_51.gemfile
   - gemfiles/active_record_50.gemfile
   - gemfiles/active_record_42.gemfile
   - gemfiles/active_record_32.gemfile
@@ -31,11 +33,26 @@ matrix:
   exclude:
     - rvm: 2.0.0-p648
       gemfile: gemfiles/active_record_50.gemfile
+    - rvm: 2.0.0-p648
+      gemfile: gemfiles/active_record_51.gemfile
+    - rvm: 2.0.0-p648
+      gemfile: gemfiles/active_record_edge.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/active_record_50.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/active_record_51.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/active_record_edge.gemfile
     - rvm: 2.3.3
       gemfile: gemfiles/active_record_32.gemfile
     - rvm: 2.4.1
       gemfile: gemfiles/active_record_32.gemfile
     - rvm: 2.4.1
       gemfile: gemfiles/active_record_42.gemfile
+  allow_failures:
+    - rvm: 2.2.6
+      gemfile: gemfiles/active_record_edge.gemfile
+    - rvm: 2.3.3
+      gemfile: gemfiles/active_record_edge.gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/active_record_edge.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change logs
 
+## (WIP)v0.1.3
+
+* Fix undefined method 'sanitize' error in Rails 5.1.0. (#7)
+
 ## v0.1.2
 
 * Add rubocop and fix its offenses. (#4)

--- a/bin/benchmark.rb
+++ b/bin/benchmark.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'bundler/setup'
 require 'active_record'
 require 'activerecord-import'

--- a/bin/db_setup.rb
+++ b/bin/db_setup.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'erb'
 require 'yaml'
 require 'active_record'

--- a/connect_db.rb
+++ b/connect_db.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'erb'
 require 'yaml'
 require 'active_record'

--- a/gemfiles/active_record_51.gemfile
+++ b/gemfiles/active_record_51.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 5.1.0.rc1', require: 'active_record'
+group :test do
+  gem 'simplecov'
+  gem 'codeclimate-test-reporter', '~> 1.0.0'
+end
+
+gemspec path: '../'

--- a/gemfiles/active_record_edge.gemfile
+++ b/gemfiles/active_record_edge.gemfile
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+git "https://github.com/rails/rails.git" do
+  gem 'activerecord', require: 'active_record'
+end
+group :test do
+  gem 'simplecov'
+  gem 'codeclimate-test-reporter', '~> 1.0.0'
+end
+
+gemspec path: '../'

--- a/lib/active_record/pg_generate_series.rb
+++ b/lib/active_record/pg_generate_series.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'active_record'
 require 'active_record/pg_generate_series/version'
 require 'active_record/pg_generate_series/extension'

--- a/lib/active_record/pg_generate_series/extension.rb
+++ b/lib/active_record/pg_generate_series/extension.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'active_record/pg_generate_series/sql_builder'
 
 module ActiveRecord

--- a/lib/active_record/pg_generate_series/sql_builder.rb
+++ b/lib/active_record/pg_generate_series/sql_builder.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     # SQL builder using PostgreSQL GENERATE_SERIES function.
     class SqlBuilder
       extend Forwardable
-      def_delegators :@ar_class, :connection, :sanitize, :quoted_table_name
+      def_delegators :@ar_class, :connection, :quoted_table_name
 
       def initialize(ar_class, first, last, step, seq_name)
         @ar_class = ar_class
@@ -28,7 +28,7 @@ module ActiveRecord
 INSERT INTO
   #{quoted_table_name} (#{@select_items.keys.map { |col| connection.quote_column_name(col) }.join(',')})
 SELECT
-  #{@select_items.values.map { |val| val.is_a?(Raw) ? val.str : sanitize(val) }.join(",\n  ")}
+  #{@select_items.values.map { |val| val.is_a?(Raw) ? val.str : connection.quote(val) }.join(",\n  ")}
 FROM
   GENERATE_SERIES(#{@first.to_i}, #{@last.to_i}, #{@step.to_i}) AS #{connection.quote_column_name(@seq_name)}
 ;

--- a/lib/active_record/pg_generate_series/sql_builder.rb
+++ b/lib/active_record/pg_generate_series/sql_builder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'forwardable'
 
 module ActiveRecord

--- a/lib/active_record/pg_generate_series/version.rb
+++ b/lib/active_record/pg_generate_series/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module ActiveRecord
   module PgGenerateSeries
     VERSION = '0.1.2'.freeze

--- a/spec/active_record/pg_generate_series/extension_spec.rb
+++ b/spec/active_record/pg_generate_series/extension_spec.rb
@@ -97,7 +97,7 @@ describe ActiveRecord::PgGenerateSeries::Extension do
       let(:options) { { debug: true } }
 
       it 'does not create records' do
-        expect { subject }.not_to change { User.count }
+        expect { subject }.not_to(change { User.count })
       end
     end
 

--- a/spec/active_record/pg_generate_series/extension_spec.rb
+++ b/spec/active_record/pg_generate_series/extension_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe ActiveRecord::PgGenerateSeries::Extension do

--- a/spec/active_record/pg_generate_series_spec.rb
+++ b/spec/active_record/pg_generate_series_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe ActiveRecord::PgGenerateSeries do

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'active_record'
 
 class User < ActiveRecord::Base


### PR DESCRIPTION
```
  1) ActiveRecord::PgGenerateSeries::Extension#insert_using_generate_series creates generate_series length User records
     Failure/Error:
       INSERT INTO
         #{quoted_table_name} (#{@select_items.keys.map { |col| connection.quote_column_name(col) }.join(',')})
       SELECT
         #{@select_items.values.map { |val| val.is_a?(Raw) ? val.str : sanitize(val) }.join(",\n  ")}
       FROM
         GENERATE_SERIES(#{@first.to_i}, #{@last.to_i}, #{@step.to_i}) AS #{connection.quote_column_name(@seq_name)}
     
     NoMethodError:
       undefined method `sanitize' for #<Class:0x00000002b478f8>
       Did you mean?  sanitize_sql
     # ./gemfiles/vendor/bundle/ruby/2.4.0/bundler/gems/rails-55ccec637212/activerecord/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
     # ./lib/active_record/pg_generate_series/sql_builder.rb:31:in `block in to_sql'
     # ./lib/active_record/pg_generate_series/sql_builder.rb:31:in `map'
     # ./lib/active_record/pg_generate_series/sql_builder.rb:31:in `to_sql'
     # ./lib/active_record/pg_generate_series/extension.rb:26:in `insert_using_generate_series'
     # ./spec/active_record/pg_generate_series/extension_spec.rb:25:in `block (3 levels) in <top (required)>'
     # ./spec/active_record/pg_generate_series/extension_spec.rb:28:in `block (4 levels) in <top (required)>'
     # ./spec/active_record/pg_generate_series/extension_spec.rb:28:in `block (3 levels) in <top (required)>'
     # ./spec/active_record/pg_generate_series/extension_spec.rb:8:in `block (3 levels) in <top (required)>'
     # ./gemfiles/vendor/bundle/ruby/2.4.0/bundler/gems/rails-55ccec637212/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `block in transaction'
     # ./gemfiles/vendor/bundle/ruby/2.4.0/bundler/gems/rails-55ccec637212/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:186:in `within_new_transaction'
     # ./gemfiles/vendor/bundle/ruby/2.4.0/bundler/gems/rails-55ccec637212/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
     # ./gemfiles/vendor/bundle/ruby/2.4.0/bundler/gems/rails-55ccec637212/activerecord/lib/active_record/transactions.rb:210:in `transaction'
     # ./spec/active_record/pg_generate_series/extension_spec.rb:7:in `block (2 levels) in <top (required)>'
```